### PR TITLE
Skip version check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cellulite"
-version = "0.3.1-nested-rtxns"
+version = "0.3.1-nested-rtxns-2"
 edition = "2024"
 license-file = "LICENSE"
 description = "Store and retrieve geojson in a memory mapped database"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -79,11 +79,6 @@ impl Cellulite {
         cancel: &(impl Fn() -> bool + Send + Sync),
         progress: &impl Progress,
     ) -> Result<()> {
-        let db_version = self.get_version(wtxn)?;
-        if db_version != Version::default() {
-            return Err(Error::VersionMismatchOnBuild(db_version));
-        }
-
         // 1.
         let (inserted_items, removed_items) =
             self.retrieve_and_clear_updated_items(wtxn, cancel, progress)?;


### PR DESCRIPTION
The version check causes v0.3.0 DBs to not be openable from v0.3.1-nested-rtxns cellulite.

A version check and an upgrade will be reintroduced at the first format change.

This PR:

- Removes the version check on build
- Bumps the version to v0.3.1-nested-rtxns-2