### PR TITLE
Fix incremental recursive insertion

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -109,19 +109,28 @@ impl Cellulite {
             if cancel() {
                 return Err(Error::BuildCanceled);
             }
-            let bitmap = self
+            let items_in_current_cell = self
                 .cell_db()
                 .get(wtxn, &Key::Cell(cell))?
                 .unwrap_or_default();
             // Awesome, we don't care about what's in the cell, wether it have multiple levels or not
-            if bitmap.len() < self.threshold || bitmap.intersection_len(&inserted_items) == 0 {
+            if items_in_current_cell.len() < self.threshold
+                || items_in_current_cell.is_disjoint(&inserted_items)
+            {
                 continue;
             }
+
+            let items_to_insert = if self.does_cell_have_children(wtxn, cell)? {
+                &items_in_current_cell & &inserted_items
+            } else {
+                items_in_current_cell.clone()
+            };
+
             self.insert_chunk_of_items_recursively(
                 wtxn,
                 cancel,
-                inserted_items.clone(),
-                bitmap,
+                items_in_current_cell,
+                items_to_insert,
                 cell,
                 &frozen_items,
             )?;
@@ -131,6 +140,22 @@ impl Cellulite {
         self.set_version(wtxn, &Version::default())?;
 
         Ok(())
+    }
+
+    fn does_cell_have_children(&self, rtxn: &RoTxn, cell: CellIndex) -> Result<bool> {
+        let Some(children) = get_children_cells(cell)? else {
+            return Ok(false);
+        };
+
+        for child in children {
+            if self.cell_db().get(rtxn, &Key::Cell(child))?.is_some()
+                || self.cell_db().get(rtxn, &Key::Belly(child))?.is_some()
+            {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
     }
 
     /// 1. We remove all the items by id of the items database


### PR DESCRIPTION
# Pull Request

This PR fixes a slowdown in GeoJSON indexing in meilisearch. When new GeoJSON documents are added to an area that is already dense, we now only send the new documents deeper into the recursive cell tree, instead of reprocessing older documents again.

Fixes https://linear.app/meilisearch/issue/SP-1888/enterprise-ditto-geojson-indexing-hangs-during-insert-items

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
